### PR TITLE
Fix the incorrect time format in github dependency bot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,14 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 09:00
+      time: "09:00"
 
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
       day: monday
-      time: 09:00
+      time: "09:00"
     update-types: ["version-update:semver-patch"]
     groups:
       minor-and-patch:


### PR DESCRIPTION
#### What type of PR is this?

Bug

<br/>

#### What this PR does / why we need it

fix the incorrect time format report from github

<img width="1716" alt="Screenshot 2025-05-16 at 2 16 00 PM" src="https://github.com/user-attachments/assets/d1d2d0f8-e93a-4c44-8b58-1bc6ca05d531" />



