### PR TITLE
Fix the incorrect left space in github dependency bot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
       interval: weekly
       day: monday
       time: "09:00"
-
   - package-ecosystem: gomod
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,6 @@ updates:
       interval: weekly
       day: monday
       time: "09:00"
-      update-types: ["version-update:semver-patch"]
     groups:
       minor-and-patch:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       interval: weekly
       day: monday
       time: "09:00"
-    update-types: ["version-update:semver-patch"]
+      update-types: ["version-update:semver-patch"]
     groups:
       minor-and-patch:
         applies-to: version-updates
@@ -27,5 +27,3 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-
-


### PR DESCRIPTION
#### What type of PR is this?

Bug

<br/>

#### What this PR does / why we need it

fix the incorrect time format report from github
![Screenshot 2025-05-16 at 2 34 30 PM](https://github.com/user-attachments/assets/926f88ea-cad4-405a-a61d-9d4c68209a76)



