### PR TITLE
Add a DeleteUser method to the keycloak helper

### DIFF
--- a/pkg/keycloak/keycloak.go
+++ b/pkg/keycloak/keycloak.go
@@ -29,6 +29,7 @@ type Client interface {
 	CreateUser(context.Context, string, string, gocloak.User) (string, error)
 	SetPassword(context.Context, string, string, string, string, bool) error
 	UpdateUser(context.Context, string, string, gocloak.User) error
+	DeleteUser(context.Context, string, string, string) error
 	GetClientRole(ctx context.Context, token string, realm string, idOfClient string, roleName string) (*gocloak.Role, error)
 	AddClientRolesToUser(ctx context.Context, token string, realm string, idOfClient string, userID string, roles []gocloak.Role) error
 	GetGroups(ctx context.Context, token string, realm string, params gocloak.GetGroupsParams) ([]*gocloak.Group, error)
@@ -206,6 +207,12 @@ func (h *Helper) SetPassword(realm, userID, password string) error {
 	ctx, cancel := context.WithTimeout(wait.CtxSeconds(10))
 	defer cancel()
 	return h.Client.SetPassword(ctx, h.Token, userID, realm, password, false)
+}
+
+func (h *Helper) DeleteUser(realm, userID string) error {
+	ctx, cancel := context.WithTimeout(wait.CtxSeconds(10))
+	defer cancel()
+	return h.Client.DeleteUser(ctx, h.Token, realm, userID)
 }
 
 func (h *Helper) UpdateUser(realm string, user gocloak.User) error {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Adds a `DeleteUser(realm, userID)` method to the keycloak `Helper` (and the underlying `Client` interface), mirroring the existing `CreateUser` / `UpdateUser` wrappers. The wrapper previously exposed no way to delete a Keycloak user.

#### Which issue(s) this PR fixes

N/A

#### Special notes for your reviewer

Thin passthrough to gocloak's `DeleteUser`; no behavior change to existing methods. Needed by the cubecmp FET new-order activation rollback, which recycles a freshly-created Keycloak user when provisioning fails after the user was created.

#### Additional documentation

```docs

```
